### PR TITLE
Adding english recipe names for micro furnace 50x plate recipes

### DIFF
--- a/locale/en/micro-furnace.cfg
+++ b/locale/en/micro-furnace.cfg
@@ -45,6 +45,12 @@ micro-behemoth-furnace=__ENTITY__micro-behemoth-furnace__
 micro-mk8-furnace=__ENTITY__micro-mk8-furnace__
 micro-mk9-furnace=__ENTITY__micro-mk9-furnace__
 micro-mk10-furnace=__ENTITY__micro-mk10-furnace__
+micro-furnace-bunch-iron-plate=__ITEM__iron-plate__
+micro-furnace-bunch-stone-brick=__ITEM__stone-brick__
+micro-furnace-bunch-copper-plate=__ITEM__copper-plate__
+micro-furnace-bunch-steel-plate=__ITEM__steel-plate__
+micro-furnace-bunch-lithium-plate=__ITEM__lithium-plate__
+micro-steel-plate=__ITEM__steel-plate__
 
 [technology-name]
 micro-furnace=__ENTITY__micro-furnace__


### PR DESCRIPTION
Recipe keys were missing in the English .cfg file. Please see attached for the before and after applying the fix. 

![Screenshot 2024-12-23 175339](https://github.com/user-attachments/assets/e1fa83c7-9a9e-4148-bbaa-3ea43647bc2d)
![Screenshot 2024-12-23 175653](https://github.com/user-attachments/assets/38f1d9ab-91a0-4855-8c3a-42d553c69b90)

This relies on the __ITEM__<plate name>__ data from the base Factorio game to work. which I dont expect to change very often if at all. 